### PR TITLE
Sleep a bit so migrations timestamp doesn't repeat

### DIFF
--- a/lib/rs-rails-base/rails_actions.rb
+++ b/lib/rs-rails-base/rails_actions.rb
@@ -7,6 +7,7 @@ module RailsBase
       migration = next_migration_number
       create_file("db/migrate/#{migration}_#{name}",
                   "#{template_path}#{name}")
+      sleep(0.1)
     end
 
     def run_migrations


### PR DESCRIPTION
When installing all features sometimes migrations ended up with the same number, so migration run fails.
Sleep 0.1 seconds to prevent this